### PR TITLE
Rewrite get_num_devices using local /dev

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -257,14 +257,17 @@ function create_and_attach_volume() {
 
     local volume=""
     for i in $(eval echo "{0..$max_attempts}") ; do
-      # If only tags on resource are prefixed with `aws:` they will all be deleted and cause a parameter validation on
-      # TagSpecifications[0].Tags[0] error to be thrown since the payload is determined to be a string, not dictionary.
-      if [ ! -z $instance_tags ]; then
-        local tag_specification="ResourceType=volume,Tags=[$instance_tags,{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
-      else:
-        local tag_specification="ResourceType=volume,Tags=[{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
-      fi
-        
+
+      # The $instance_tags variable could be empty and will cause a TagSpecifications[0].Tags[0] error if
+      # it is passed as an empty value because it must be comma-separated from the other key-value pairs.
+      # Use a Shell Parameter Expansion to determine if the variable contains a value or not. If it has a value, 
+      # append a comma at the end so the aws cli syntax is compliant when it is subbed into the tag_specification variable.
+      local instance_tags=${instance_tags:+${instance_tags},}
+      local tag_specification="ResourceType=volume,Tags=[$instance_tags{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
+
+      # Note: Shellcheck says the $vars in this command should be double quoted to prevent globbing and word-splitting,
+      # but this ends up making the '--encrypted' argument to fail during the execution of the install script. Conversely, NOT putting double-quotes
+      # around $tag_specification causes a parsing error due to the space in the $timestamp value (added to $tag_specification above).
       local volume=$(\
           aws ec2 create-volume \
               --region $region \

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -261,7 +261,7 @@ function create_and_attach_volume() {
       # TagSpecifications[0].Tags[0] error to be thrown since the payload is determined to be a string, not dictionary.
       if [ ! -z $instance_tags ]; then
         local tag_specification="ResourceType=volume,Tags=[$instance_tags,{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
-      else:
+      else
         local tag_specification="ResourceType=volume,Tags=[{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
       fi
         

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -57,40 +57,8 @@ until [ -d "${MOUNTPOINT}" ]; do
 done
 
 get_num_devices() {
-  # This tag is added to all devices attached by this ebs-autoscale in the create-ebs-volume script it's presence indicates
-  # a device that has been added by auto-expansion rather than an EBS volume attached for other reasons or at startup.
-  TAG=amazon-ebs-autoscale-creation-time
-
-  # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
-  # excluded as they aren't relevant to autoscaling
-  local attached_volumes=""
-  local max_attempts=${AWS_MAX_ATTEMPTS:-10}
-
-  # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
-  # eventually getting a usable value. The >= 0 test is really a test that we got an integer response
-  for i in $(eval echo "{0..$max_attempts}") ; do
-      local attached_volumes_response=""
-
-      attached_volumes_response=$(
-        aws ec2 describe-volumes \
-            --region $AWS_REGION \
-            --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$TAG
-       )
-
-      attached_volumes=$(echo "$attached_volumes_response" | jq '.Volumes | length')
-      if [ "$attached_volumes" -ge 0 ]; then
-          break
-      fi
-
-      if [ $i -eq $max_attempts ] ; then
-        logthis "Could not determine the number of attached_volumes after $i attempts. Last response was: $attached_volumes_response"
-        break
-      fi
-
-      sleep $(( 2 ** i + $RANDOM %3 ))
-  done
-
-  echo "$attached_volumes"
+  # count the number of devices attached at `xvdb`
+  ls /dev/xvdb* 2> /dev/null | wc -l
 }
 
 calc_threshold() {
@@ -199,8 +167,8 @@ LOG_COUNT=$LOG_INTERVAL
 # time in seconds between event loops
 # keep this low so that rapid increases in utilization are detected
 DETECTION_INTERVAL=$(get_config_value .detection_interval)
-# get the number of devices once when the script first starts
-NUM_DEVICES=$(get_num_devices)
+# default to 1 since the install.sh script creates an initial volume 
+NUM_DEVICES=1
 THRESHOLD=$(calc_threshold "${NUM_DEVICES}")
 while true; do
 


### PR DESCRIPTION
This PR implements get_num_devices function using the local devices /dev/ file system to prevent AWS API rate limits error